### PR TITLE
chore: update ci macos version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
 
   build-ios-lmfs:
     runs-on:
-      labels: macos-latest-xlarge
+      labels: macos-26-xlarge
     timeout-minutes: 45
     env:
       TURBO_CACHE_DIR: .turbo/ios
@@ -290,7 +290,7 @@ jobs:
 
   build-ios-odrd:
     runs-on:
-      labels: macos-latest-xlarge
+      labels: macos-26-xlarge
     timeout-minutes: 45
     env:
       TURBO_CACHE_DIR: .turbo/ios


### PR DESCRIPTION
- Pin CI macos version to 26

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR